### PR TITLE
feat: add security context, health probes, and fix worker command

### DIFF
--- a/charts/frankenphp/templates/crons.yaml
+++ b/charts/frankenphp/templates/crons.yaml
@@ -26,11 +26,19 @@ spec:
           {{- if $.Values.serviceAccount }}
           serviceAccountName: {{ include "helm-frankenphp.serviceAccountName" $ }}
           {{- end }}
+          {{- with $.Values.podSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           restartPolicy: {{ (default .restartPolicy "Never") }}
           containers:
             - name: {{ $cronName | lower }}
               image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag | default $.Chart.AppVersion }}"
               imagePullPolicy: {{ $.Values.image.pullPolicy | default "IfNotPresent" }}
+              {{- with $.Values.containerSecurityContext }}
+              securityContext:
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
               command:
                 - "/bin/sh"
                 - "-c"

--- a/charts/frankenphp/templates/deployment.yaml
+++ b/charts/frankenphp/templates/deployment.yaml
@@ -28,10 +28,18 @@ spec:
       {{- if .Values.serviceAccount }}
       serviceAccountName: {{ include "helm-frankenphp.serviceAccountName" . }}
       {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy | default "IfNotPresent" }}
+          {{- with .Values.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 80
@@ -44,6 +52,14 @@ spec:
               name: metrics
           {{- with .Values.resources }}
           resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.env }}

--- a/charts/frankenphp/templates/jobs.yaml
+++ b/charts/frankenphp/templates/jobs.yaml
@@ -32,11 +32,19 @@ spec:
       {{- if $context.Values.serviceAccount }}
       serviceAccountName: {{ include "helm-frankenphp.serviceAccountName" $context }}
       {{- end }}
+      {{- with $context.Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       restartPolicy: {{ $job.restartPolicy | default "OnFailure" }}
       containers:
         - name: {{ $job.name | replace "_" "-" }}
           image: "{{ $context.Values.image.repository }}:{{ $context.Values.image.tag | default $context.Chart.AppVersion }}"
           imagePullPolicy: {{ $context.Values.image.pullPolicy | default "IfNotPresent" }}
+          {{- with $context.Values.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           command: ["/bin/sh", "-c"]
           args:
             - {{ $job.command }}

--- a/charts/frankenphp/templates/worker.yaml
+++ b/charts/frankenphp/templates/worker.yaml
@@ -32,11 +32,19 @@ spec:
       {{- if $.Values.serviceAccount }}
       serviceAccountName: {{ include "helm-frankenphp.serviceAccountName" $ }}
       {{- end }}
+      {{- with $.Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       restartPolicy: Always
       containers:
         - name: {{ $workerName }}
           image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag | default $.Chart.AppVersion }}"
           imagePullPolicy: {{ $.Values.image.pullPolicy | default "IfNotPresent" }}
+          {{- with $.Values.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           lifecycle:
             preStop:
               exec:
@@ -45,12 +53,19 @@ spec:
           env:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          command: # todo: find a better way to handle this
-            - "/bin/sh"
-            - "-c"
+          command: ["/bin/sh", "-c"]
+          args:
             - {{ .command | quote }}
           {{- with $.Values.resources }}
           resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $.Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $.Values.readinessProbe }}
+          readinessProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- if or $.Values.php.ini $.Values.volumeMounts }}

--- a/charts/frankenphp/tests/probes_test.yaml
+++ b/charts/frankenphp/tests/probes_test.yaml
@@ -1,0 +1,90 @@
+suite: Health Probes
+templates:
+  - deployment.yaml
+tests:
+  - it: should not have livenessProbe by default
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].livenessProbe
+
+  - it: should not have readinessProbe by default
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].readinessProbe
+
+  - it: should set livenessProbe when configured
+    set:
+      livenessProbe:
+        httpGet:
+          path: /
+          port: http
+        initialDelaySeconds: 10
+        periodSeconds: 10
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: http
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.initialDelaySeconds
+          value: 10
+
+  - it: should set readinessProbe when configured
+    set:
+      readinessProbe:
+        httpGet:
+          path: /
+          port: http
+        initialDelaySeconds: 5
+        periodSeconds: 10
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.initialDelaySeconds
+          value: 5
+
+  - it: should support exec probe
+    set:
+      livenessProbe:
+        exec:
+          command:
+            - php
+            - -r
+            - "echo 'ok';"
+        periodSeconds: 30
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.exec.command[0]
+          value: php
+---
+suite: Health Probes - Workers
+templates:
+  - worker.yaml
+tests:
+  - it: should not have livenessProbe in workers by default
+    set:
+      consumers:
+        - name: "queue"
+          command: "php bin/console messenger:consume"
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].livenessProbe
+
+  - it: should set livenessProbe in workers when configured
+    set:
+      consumers:
+        - name: "queue"
+          command: "php bin/console messenger:consume"
+      livenessProbe:
+        httpGet:
+          path: /
+          port: http
+        periodSeconds: 10
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /

--- a/charts/frankenphp/tests/security_context_test.yaml
+++ b/charts/frankenphp/tests/security_context_test.yaml
@@ -1,0 +1,87 @@
+suite: Security Context
+templates:
+  - deployment.yaml
+tests:
+  - it: should not have podSecurityContext by default
+    asserts:
+      - notExists:
+          path: spec.template.spec.securityContext
+
+  - it: should set podSecurityContext when configured
+    set:
+      podSecurityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 1000
+
+  - it: should not have containerSecurityContext by default
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].securityContext
+
+  - it: should set containerSecurityContext when configured
+    set:
+      containerSecurityContext:
+        allowPrivilegeEscalation: false
+        runAsNonRoot: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true
+
+  - it: should support capabilities drop in containerSecurityContext
+    set:
+      containerSecurityContext:
+        capabilities:
+          drop:
+            - ALL
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop[0]
+          value: ALL
+---
+suite: Security Context - Workers
+templates:
+  - worker.yaml
+tests:
+  - it: should not have podSecurityContext in workers by default
+    set:
+      consumers:
+        - name: "queue"
+          command: "php bin/console messenger:consume"
+    asserts:
+      - notExists:
+          path: spec.template.spec.securityContext
+
+  - it: should set podSecurityContext in workers when configured
+    set:
+      consumers:
+        - name: "queue"
+          command: "php bin/console messenger:consume"
+      podSecurityContext:
+        runAsNonRoot: true
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+
+  - it: should set containerSecurityContext in workers when configured
+    set:
+      consumers:
+        - name: "queue"
+          command: "php bin/console messenger:consume"
+      containerSecurityContext:
+        allowPrivilegeEscalation: false
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false

--- a/charts/frankenphp/values.schema.json
+++ b/charts/frankenphp/values.schema.json
@@ -352,6 +352,22 @@
             "items": {
                 "type": "object"
             }
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "description": "Pod-level security context applied to all workloads"
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "description": "Container-level security context applied to all containers"
+        },
+        "livenessProbe": {
+            "type": "object",
+            "description": "Liveness probe configuration for the main deployment and workers"
+        },
+        "readinessProbe": {
+            "type": "object",
+            "description": "Readiness probe configuration for the main deployment and workers"
         }
     }
 }

--- a/charts/frankenphp/values.yaml
+++ b/charts/frankenphp/values.yaml
@@ -50,6 +50,40 @@ consumers: []
 #    command: "php bin/console messenger:consume"
 #    replicas: 1
 
+podSecurityContext: {}
+#  runAsNonRoot: true
+#  runAsUser: 1000
+#  fsGroup: 1000
+#  seccompProfile:
+#    type: RuntimeDefault
+
+containerSecurityContext: {}
+#  allowPrivilegeEscalation: false
+#  readOnlyRootFilesystem: false
+#  runAsNonRoot: true
+#  runAsUser: 1000
+#  capabilities:
+#    drop:
+#      - ALL
+#  seccompProfile:
+#    type: RuntimeDefault
+
+livenessProbe: {}
+#  httpGet:
+#    path: /
+#    port: http
+#  initialDelaySeconds: 10
+#  periodSeconds: 10
+#  failureThreshold: 3
+
+readinessProbe: {}
+#  httpGet:
+#    path: /
+#    port: http
+#  initialDelaySeconds: 5
+#  periodSeconds: 10
+#  failureThreshold: 3
+
 affinity: {}
 
 nodeSelector: {}

--- a/examples/12-security.yaml
+++ b/examples/12-security.yaml
@@ -1,0 +1,48 @@
+# Example: Security-hardened deployment
+# Demonstrates podSecurityContext, containerSecurityContext, and health probes.
+# Note: FrankenPHP/Caddy may write to /tmp and /var — avoid readOnlyRootFilesystem: true
+# unless your image is specifically built to handle it.
+image:
+  repository: dunglas/frankenphp
+  tag: latest
+
+deployment:
+  replicas: 2
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  fsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
+
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  runAsNonRoot: true
+  runAsUser: 1000
+  capabilities:
+    drop:
+      - ALL
+
+livenessProbe:
+  httpGet:
+    path: /
+    port: http
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  failureThreshold: 3
+
+resources:
+  requests:
+    cpu: "100m"
+    memory: "128Mi"
+  limits:
+    memory: "256Mi"


### PR DESCRIPTION
## Summary
- Add `securityContext` support for pod and container-level security settings
- Add liveness and readiness health probe configuration
- Fix worker command handling

## Test results
- `make lint`: PASS
- `make unit-test`: 21 suites, 135 tests — all PASS
- `make validate`: all 14 example files valid (kubeconform k8s 1.29)

## Notes
This is part of a stacked PR series. Each PR adds one feature and is based on the previous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)