### PR TITLE
feat: add PodDisruptionBudget support

### DIFF
--- a/charts/frankenphp/templates/pdb.yaml
+++ b/charts/frankenphp/templates/pdb.yaml
@@ -1,0 +1,18 @@
+{{- if (.Values.podDisruptionBudget).enabled }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    {{- include "helm-frankenphp.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "helm-frankenphp.selectorLabels" . | nindent 6 }}
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- else }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable | default 1 }}
+  {{- end }}
+{{- end }}

--- a/charts/frankenphp/templates/pdb.yaml
+++ b/charts/frankenphp/templates/pdb.yaml
@@ -3,7 +3,7 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ include "helm-frankenphp.fullname" . }}
   labels:
     {{- include "helm-frankenphp.labels" . | nindent 4 }}
 spec:

--- a/charts/frankenphp/tests/pdb_test.yaml
+++ b/charts/frankenphp/tests/pdb_test.yaml
@@ -1,0 +1,74 @@
+suite: PodDisruptionBudget
+templates:
+  - pdb.yaml
+tests:
+  - it: should not create PDB when disabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create PDB when enabled
+    set:
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 1
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - isAPIVersion:
+          of: policy/v1
+      - matchRegex:
+          path: metadata.name
+          pattern: RELEASE-NAME$
+
+  - it: should set minAvailable when configured
+    set:
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 2
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: 2
+
+  - it: should default minAvailable to 1
+    set:
+      podDisruptionBudget:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: 1
+
+  - it: should set maxUnavailable when configured
+    set:
+      podDisruptionBudget:
+        enabled: true
+        maxUnavailable: 1
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+      - notExists:
+          path: spec.minAvailable
+
+  - it: should prefer maxUnavailable over minAvailable when both set
+    set:
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 2
+        maxUnavailable: 1
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+      - notExists:
+          path: spec.minAvailable
+
+  - it: should have correct selector labels
+    set:
+      podDisruptionBudget:
+        enabled: true
+    asserts:
+      - exists:
+          path: spec.selector.matchLabels

--- a/charts/frankenphp/tests/pdb_test.yaml
+++ b/charts/frankenphp/tests/pdb_test.yaml
@@ -19,7 +19,7 @@ tests:
           of: policy/v1
       - matchRegex:
           path: metadata.name
-          pattern: RELEASE-NAME$
+          pattern: ^RELEASE-NAME-frankenphp$
 
   - it: should set minAvailable when configured
     set:

--- a/charts/frankenphp/values.schema.json
+++ b/charts/frankenphp/values.schema.json
@@ -368,6 +368,22 @@
         "readinessProbe": {
             "type": "object",
             "description": "Readiness probe configuration for the main deployment and workers"
+        },
+        "podDisruptionBudget": {
+            "type": "object",
+            "description": "PodDisruptionBudget configuration",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable PodDisruptionBudget"
+                },
+                "minAvailable": {
+                    "description": "Minimum number of pods that must be available (integer or percentage string)"
+                },
+                "maxUnavailable": {
+                    "description": "Maximum number of pods that can be unavailable (integer or percentage string)"
+                }
+            }
         }
     }
 }

--- a/charts/frankenphp/values.yaml
+++ b/charts/frankenphp/values.yaml
@@ -142,6 +142,11 @@ ingress: {}
 
 monitoring: false
 
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+#  maxUnavailable: 1
+
 #serviceAccount:
 #  create: false
 #  name: ""

--- a/examples/08-high-availability.yaml
+++ b/examples/08-high-availability.yaml
@@ -24,3 +24,8 @@ affinity:
                   - frankenphp
           topologyKey: kubernetes.io/hostname
 
+# Keep at least 2 pods available during voluntary disruptions (node drains, upgrades)
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 2
+


### PR DESCRIPTION
## Summary
- Add `podDisruptionBudget.enabled` flag with `minAvailable`/`maxUnavailable` configuration
- Renders `pdb.yaml` template when enabled

## Test results
- `make lint`: PASS
- `make unit-test`: 21 suites, 135 tests — all PASS
- `make validate`: all 14 example files valid (kubeconform k8s 1.29)

## Notes
Stacked on: `feat/hpa-deployment-workers`

🤖 Generated with [Claude Code](https://claude.com/claude-code)