### PR TITLE
feat: add nameOverride, podAnnotations, and terminationGracePeriodSeconds

### DIFF
--- a/charts/frankenphp/templates/crons.yaml
+++ b/charts/frankenphp/templates/crons.yaml
@@ -18,6 +18,11 @@ spec:
     spec:
       backoffLimit: {{ (default .backoffLimit 0) }}
       template:
+        metadata:
+          {{- with $.Values.podAnnotations }}
+          annotations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         spec:
           {{- with $.Values.image.pullSecrets | default (list)}}
           imagePullSecrets:
@@ -73,6 +78,9 @@ spec:
           {{- with $.Values.tolerations }}
           tolerations:
             {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $.Values.terminationGracePeriodSeconds }}
+          terminationGracePeriodSeconds: {{ . }}
           {{- end }}
           {{- if or $.Values.php.ini $.Values.volumes }}
           volumes:

--- a/charts/frankenphp/templates/deployment.yaml
+++ b/charts/frankenphp/templates/deployment.yaml
@@ -93,6 +93,9 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ . }}
+      {{- end }}
       {{- if or .Values.caddyfile .Values.php.ini .Values.volumes }}
       volumes:
       {{- if .Values.caddyfile }}

--- a/charts/frankenphp/templates/jobs.yaml
+++ b/charts/frankenphp/templates/jobs.yaml
@@ -79,6 +79,9 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $context.Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ . }}
+      {{- end }}
       {{- if or $context.Values.php.ini $context.Values.volumes }}
       volumes:
         {{- if $context.Values.php.ini }}

--- a/charts/frankenphp/templates/worker.yaml
+++ b/charts/frankenphp/templates/worker.yaml
@@ -91,6 +91,9 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $.Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ . }}
+      {{- end }}
       {{- if or $.Values.php.ini $.Values.volumes }}
       volumes:
         {{- if $.Values.php.ini }}

--- a/charts/frankenphp/tests/deployment_test.yaml
+++ b/charts/frankenphp/tests/deployment_test.yaml
@@ -108,3 +108,21 @@ tests:
       - equal:
           path: spec.template.spec.serviceAccountName
           value: my-sa
+
+  - it: should not have pod annotations by default
+    asserts:
+      - notExists:
+          path: spec.template.metadata.annotations
+
+  - it: should set pod annotations when configured
+    set:
+      podAnnotations:
+        custom-annotation: "my-value"
+        prometheus.io/scrape: "true"
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["custom-annotation"]
+          value: "my-value"
+      - equal:
+          path: spec.template.metadata.annotations["prometheus.io/scrape"]
+          value: "true"

--- a/charts/frankenphp/tests/scheduling_test.yaml
+++ b/charts/frankenphp/tests/scheduling_test.yaml
@@ -130,3 +130,30 @@ tests:
       - equal:
           path: spec.template.spec.tolerations[0].key
           value: example_key
+
+  - it: should set terminationGracePeriodSeconds in Deployment
+    template: deployment.yaml
+    set:
+      terminationGracePeriodSeconds: 60
+    asserts:
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 60
+
+  - it: should not set terminationGracePeriodSeconds by default
+    template: deployment.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.terminationGracePeriodSeconds
+
+  - it: should set terminationGracePeriodSeconds in Worker
+    template: worker.yaml
+    set:
+      consumers:
+        - name: "queue"
+          command: "php bin/console messenger:consume"
+      terminationGracePeriodSeconds: 120
+    asserts:
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 120

--- a/charts/frankenphp/values.schema.json
+++ b/charts/frankenphp/values.schema.json
@@ -384,6 +384,26 @@
                     "description": "Maximum number of pods that can be unavailable (integer or percentage string)"
                 }
             }
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "Override the chart name used in resource names and labels"
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "Override the fully qualified app name used in resource names"
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all pods",
+            "additionalProperties": {
+                "type": "string"
+            }
+        },
+        "terminationGracePeriodSeconds": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Override the default termination grace period for all pods"
         }
     }
 }

--- a/charts/frankenphp/values.yaml
+++ b/charts/frankenphp/values.yaml
@@ -5,7 +5,14 @@ image:
 #  pullSecrets:
 #     - name: myRegistryKeySecret
 
+# nameOverride and fullnameOverride let you change the chart name used in resource names and labels.
+#nameOverride: ""
+#fullnameOverride: ""
 
+# Annotations to add to all pods (deployment, workers, crons, jobs).
+podAnnotations: {}
+#  prometheus.io/scrape: "true"
+#  custom-annotation: "value"
 
 php:
   ini: ""
@@ -89,6 +96,10 @@ affinity: {}
 nodeSelector: {}
 
 tolerations: []
+
+# terminationGracePeriodSeconds defines how long Kubernetes waits for a pod to shut down gracefully.
+# Increase this for workers that need time to finish processing current messages.
+#terminationGracePeriodSeconds: 30
 
 # Extra volumes to mount into all pods (deployment, workers, crons, jobs).
 # Use this to inject secrets or configmaps as files into your containers.


### PR DESCRIPTION
## Summary
- Add `nameOverride` for customizing resource name prefix
- Add `podAnnotations` for arbitrary pod-level annotations
- Add `terminationGracePeriodSeconds` configuration

## Test results
- `make lint`: PASS
- `make unit-test`: 21 suites, 135 tests — all PASS
- `make validate`: all 14 example files valid (kubeconform k8s 1.29)

## Notes
Stacked on: `fix/podmonitor-service-bugs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)