### PR TITLE
feat: add topologySpreadConstraints, priorityClassName, initContainers; fix template consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,54 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- `podSecurityContext` and `containerSecurityContext` fields — inject security context into all workloads (deployment, workers, crons, jobs)
+- `livenessProbe` and `readinessProbe` fields — configurable health probes for the main deployment and workers
+- `autoscaling` section — HorizontalPodAutoscaler support for the main deployment (`autoscaling/v2`)
+- Per-worker HPA via `autoscale`, `minReplicas`, `maxReplicas`, `targetCPUUtilizationPercentage`, and `targetMemoryUtilizationPercentage` fields on consumer entries
+- `podDisruptionBudget` section — PodDisruptionBudget support with `minAvailable`/`maxUnavailable`
+- Example `12-security.yaml` demonstrating security-hardened deployment
+
+### Changed
+- Worker `command` now uses `command + args` pattern instead of wrapping in `/bin/sh -c` array
+- Deployment `spec.replicas` is omitted when `autoscaling.enabled: true` to allow HPA to manage replica count
+
+## [0.3.0] - 2024
+
+### Added
+- Helm hooks support for jobs via `annotations` field
+
+### Changed
+- Harmonized command structure across jobs, crons, and workers for consistency
+
+### Fixed
+- Various template alignment and indentation issues
+
+## [0.2.0] - 2024
+
+### Added
+- Generic `volumes` and `volumeMounts` support — inject Secrets, ConfigMaps, and PVCs into all pods
+- Example `11-secrets-volumes.yaml` demonstrating volume injection
+- Unit tests for volume and volumeMount management
+- Artifact Hub badge in README
+
+## [0.1.1] - 2024
+
+### Added
+- Initial public release published to Artifact Hub
+- Main application Deployment with HTTP/HTTPS/metrics ports
+- Workers (consumers) as separate Deployments
+- CronJobs for scheduled tasks
+- Jobs with Helm hook support
+- Service, Ingress, and PodMonitor templates
+- Custom PHP ini and Caddyfile injection
+- ServiceAccount support
+- 12 example configurations covering dev, production, HA, Symfony, and more
+- CI/CD pipeline with helm-unittest, helm lint, kubeconform, and KinD integration tests
+- Automated release pipeline via chart-releaser

--- a/charts/frankenphp/templates/crons.yaml
+++ b/charts/frankenphp/templates/crons.yaml
@@ -30,6 +30,10 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with $.Values.initContainers }}
+          initContainers:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           restartPolicy: {{ (default .restartPolicy "Never") }}
           containers:
             - name: {{ $cronName | lower }}
@@ -73,6 +77,16 @@ spec:
           {{- with $.Values.tolerations }}
           tolerations:
             {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $.Values.topologySpreadConstraints }}
+          topologySpreadConstraints:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $.Values.priorityClassName }}
+          priorityClassName: {{ . }}
+          {{- end }}
+          {{- with $.Values.terminationGracePeriodSeconds }}
+          terminationGracePeriodSeconds: {{ . }}
           {{- end }}
           {{- if or $.Values.php.ini $.Values.volumes }}
           volumes:

--- a/charts/frankenphp/templates/crons.yaml
+++ b/charts/frankenphp/templates/crons.yaml
@@ -26,11 +26,19 @@ spec:
           {{- if $.Values.serviceAccount }}
           serviceAccountName: {{ include "helm-frankenphp.serviceAccountName" $ }}
           {{- end }}
+          {{- with $.Values.podSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           restartPolicy: {{ (default .restartPolicy "Never") }}
           containers:
             - name: {{ $cronName | lower }}
               image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag | default $.Chart.AppVersion }}"
               imagePullPolicy: {{ $.Values.image.pullPolicy | default "IfNotPresent" }}
+              {{- with $.Values.containerSecurityContext }}
+              securityContext:
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
               command:
                 - "/bin/sh"
                 - "-c"

--- a/charts/frankenphp/templates/deployment.yaml
+++ b/charts/frankenphp/templates/deployment.yaml
@@ -28,10 +28,18 @@ spec:
       {{- if .Values.serviceAccount }}
       serviceAccountName: {{ include "helm-frankenphp.serviceAccountName" . }}
       {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy | default "IfNotPresent" }}
+          {{- with .Values.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 80
@@ -44,6 +52,14 @@ spec:
               name: metrics
           {{- with .Values.resources }}
           resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.env }}

--- a/charts/frankenphp/templates/deployment.yaml
+++ b/charts/frankenphp/templates/deployment.yaml
@@ -95,6 +95,9 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ . }}
+      {{- end }}
       {{- if or .Values.caddyfile .Values.php.ini .Values.volumes }}
       volumes:
       {{- if .Values.caddyfile }}

--- a/charts/frankenphp/templates/deployment.yaml
+++ b/charts/frankenphp/templates/deployment.yaml
@@ -8,7 +8,9 @@ metadata:
   labels:
     {{- include "helm-frankenphp.labels" . | nindent 4 }}
 spec:
+  {{- if not (.Values.autoscaling).enabled }}
   replicas: {{ .Values.deployment.replicas | default 1 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "helm-frankenphp.selectorLabels" . | nindent 6 }}

--- a/charts/frankenphp/templates/deployment.yaml
+++ b/charts/frankenphp/templates/deployment.yaml
@@ -64,6 +64,10 @@ spec:
           readinessProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.env }}
           env:
             {{- toYaml . | nindent 12 }}

--- a/charts/frankenphp/templates/deployment.yaml
+++ b/charts/frankenphp/templates/deployment.yaml
@@ -34,6 +34,10 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.initContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -98,6 +102,13 @@ spec:
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
       {{- end }}
       {{- with .Values.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ . }}

--- a/charts/frankenphp/templates/hpa.yaml
+++ b/charts/frankenphp/templates/hpa.yaml
@@ -1,0 +1,33 @@
+{{- if and .Values.deployment (.Values.autoscaling).enabled }}
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    {{- include "helm-frankenphp.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Release.Name }}
+  minReplicas: {{ .Values.autoscaling.minReplicas | default 1 }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas | default 10 }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/frankenphp/templates/jobs.yaml
+++ b/charts/frankenphp/templates/jobs.yaml
@@ -32,11 +32,19 @@ spec:
       {{- if $context.Values.serviceAccount }}
       serviceAccountName: {{ include "helm-frankenphp.serviceAccountName" $context }}
       {{- end }}
+      {{- with $context.Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       restartPolicy: {{ $job.restartPolicy | default "OnFailure" }}
       containers:
         - name: {{ $job.name | replace "_" "-" }}
           image: "{{ $context.Values.image.repository }}:{{ $context.Values.image.tag | default $context.Chart.AppVersion }}"
           imagePullPolicy: {{ $context.Values.image.pullPolicy | default "IfNotPresent" }}
+          {{- with $context.Values.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           command: ["/bin/sh", "-c"]
           args:
             - {{ $job.command }}

--- a/charts/frankenphp/templates/jobs.yaml
+++ b/charts/frankenphp/templates/jobs.yaml
@@ -36,6 +36,10 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $context.Values.initContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       restartPolicy: {{ $job.restartPolicy | default "OnFailure" }}
       containers:
         - name: {{ $job.name | replace "_" "-" }}
@@ -78,6 +82,16 @@ spec:
       {{- with $context.Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $context.Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $context.Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      {{- with $context.Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ . }}
       {{- end }}
       {{- if or $context.Values.php.ini $context.Values.volumes }}
       volumes:

--- a/charts/frankenphp/templates/monitoring.yaml
+++ b/charts/frankenphp/templates/monitoring.yaml
@@ -3,7 +3,9 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
-  name: {{- $name := printf "%s-%s" .Chart.Name .Release.Name }}
+  name: {{ printf "%s-%s" .Release.Name .Chart.Name }}
+  labels:
+    {{- include "helm-frankenphp.labels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:

--- a/charts/frankenphp/templates/pdb.yaml
+++ b/charts/frankenphp/templates/pdb.yaml
@@ -1,0 +1,18 @@
+{{- if (.Values.podDisruptionBudget).enabled }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    {{- include "helm-frankenphp.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "helm-frankenphp.selectorLabels" . | nindent 6 }}
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- else }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable | default 1 }}
+  {{- end }}
+{{- end }}

--- a/charts/frankenphp/templates/service.yaml
+++ b/charts/frankenphp/templates/service.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "helm-frankenphp.labels" . | nindent 4 }}
 spec:
-  type: "ClusterIP"
+  type: {{ .Values.service.type | default "ClusterIP" }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http

--- a/charts/frankenphp/templates/worker-hpa.yaml
+++ b/charts/frankenphp/templates/worker-hpa.yaml
@@ -1,0 +1,37 @@
+{{- $context := . }}
+{{- range .Values.consumers }}
+{{- if .autoscale }}
+{{- $workerName := printf "%s-%s-%s" $context.Release.Name "worker" .name }}
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ $workerName }}
+  labels:
+    {{- include "helm-frankenphp.labels" $context | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ $workerName }}
+  minReplicas: {{ .minReplicas | default 1 }}
+  maxReplicas: {{ .maxReplicas | default 10 }}
+  metrics:
+    {{- if .targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/frankenphp/templates/worker.yaml
+++ b/charts/frankenphp/templates/worker.yaml
@@ -36,6 +36,10 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $.Values.initContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       restartPolicy: Always
       containers:
         - name: {{ $workerName }}
@@ -94,6 +98,13 @@ spec:
       {{- with $.Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $.Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $.Values.priorityClassName }}
+      priorityClassName: {{ . }}
       {{- end }}
       {{- with $.Values.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ . }}

--- a/charts/frankenphp/templates/worker.yaml
+++ b/charts/frankenphp/templates/worker.yaml
@@ -32,11 +32,19 @@ spec:
       {{- if $.Values.serviceAccount }}
       serviceAccountName: {{ include "helm-frankenphp.serviceAccountName" $ }}
       {{- end }}
+      {{- with $.Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       restartPolicy: Always
       containers:
         - name: {{ $workerName }}
           image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag | default $.Chart.AppVersion }}"
           imagePullPolicy: {{ $.Values.image.pullPolicy | default "IfNotPresent" }}
+          {{- with $.Values.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           lifecycle:
             preStop:
               exec:
@@ -45,12 +53,19 @@ spec:
           env:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          command: # todo: find a better way to handle this
-            - "/bin/sh"
-            - "-c"
+          command: ["/bin/sh", "-c"]
+          args:
             - {{ .command | quote }}
           {{- with $.Values.resources }}
           resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $.Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $.Values.readinessProbe }}
+          readinessProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- if or $.Values.php.ini $.Values.volumeMounts }}

--- a/charts/frankenphp/templates/worker.yaml
+++ b/charts/frankenphp/templates/worker.yaml
@@ -68,6 +68,10 @@ spec:
           readinessProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with $.Values.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- if or $.Values.php.ini $.Values.volumeMounts }}
           volumeMounts:
             {{- if $.Values.php.ini }}

--- a/charts/frankenphp/templates/worker.yaml
+++ b/charts/frankenphp/templates/worker.yaml
@@ -91,6 +91,9 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $.Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ . }}
+      {{- end }}
       {{- if or $.Values.php.ini $.Values.volumes }}
       volumes:
         {{- if $.Values.php.ini }}

--- a/charts/frankenphp/tests/deployment_test.yaml
+++ b/charts/frankenphp/tests/deployment_test.yaml
@@ -108,3 +108,21 @@ tests:
       - equal:
           path: spec.template.spec.serviceAccountName
           value: my-sa
+
+  - it: should not have pod annotations by default
+    asserts:
+      - notExists:
+          path: spec.template.metadata.annotations
+
+  - it: should set pod annotations when configured
+    set:
+      podAnnotations:
+        custom-annotation: "my-value"
+        prometheus.io/scrape: "true"
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["custom-annotation"]
+          value: "my-value"
+      - equal:
+          path: spec.template.metadata.annotations["prometheus.io/scrape"]
+          value: "true"

--- a/charts/frankenphp/tests/hpa_test.yaml
+++ b/charts/frankenphp/tests/hpa_test.yaml
@@ -1,0 +1,98 @@
+suite: HPA - Main Deployment
+templates:
+  - hpa.yaml
+tests:
+  - it: should not create HPA when autoscaling is disabled
+    set:
+      deployment:
+        replicas: 3
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create HPA when autoscaling is enabled
+    set:
+      deployment:
+        replicas: 3
+      autoscaling:
+        enabled: true
+        minReplicas: 2
+        maxReplicas: 8
+        targetCPUUtilizationPercentage: 75
+    asserts:
+      - isKind:
+          of: HorizontalPodAutoscaler
+      - isAPIVersion:
+          of: autoscaling/v2
+      - equal:
+          path: spec.minReplicas
+          value: 2
+      - equal:
+          path: spec.maxReplicas
+          value: 8
+      - equal:
+          path: spec.scaleTargetRef.kind
+          value: Deployment
+      - matchRegex:
+          path: spec.scaleTargetRef.name
+          pattern: RELEASE-NAME$
+
+  - it: should set CPU metric when targetCPUUtilizationPercentage is set
+    set:
+      deployment:
+        replicas: 3
+      autoscaling:
+        enabled: true
+        targetCPUUtilizationPercentage: 80
+    asserts:
+      - equal:
+          path: spec.metrics[0].type
+          value: Resource
+      - equal:
+          path: spec.metrics[0].resource.name
+          value: cpu
+      - equal:
+          path: spec.metrics[0].resource.target.averageUtilization
+          value: 80
+
+  - it: should set memory metric when targetMemoryUtilizationPercentage is set
+    set:
+      deployment:
+        replicas: 3
+      autoscaling:
+        enabled: true
+        targetCPUUtilizationPercentage: 80
+        targetMemoryUtilizationPercentage: 70
+    asserts:
+      - equal:
+          path: spec.metrics[1].type
+          value: Resource
+      - equal:
+          path: spec.metrics[1].resource.name
+          value: memory
+      - equal:
+          path: spec.metrics[1].resource.target.averageUtilization
+          value: 70
+---
+suite: HPA - Deployment replicas
+templates:
+  - deployment.yaml
+tests:
+  - it: should include replicas when autoscaling is disabled
+    set:
+      deployment:
+        replicas: 3
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 3
+
+  - it: should omit replicas when autoscaling is enabled
+    set:
+      deployment:
+        replicas: 3
+      autoscaling:
+        enabled: true
+    asserts:
+      - notExists:
+          path: spec.replicas

--- a/charts/frankenphp/tests/monitoring_test.yaml
+++ b/charts/frankenphp/tests/monitoring_test.yaml
@@ -14,6 +14,19 @@ tests:
           of: PodMonitor
       - isAPIVersion:
           of: monitoring.coreos.com/v1
+  - it: should have a non-empty metadata name
+    set:
+      monitoring: true
+    asserts:
+      - matchRegex:
+          path: metadata.name
+          pattern: RELEASE-NAME
+  - it: should have correct labels
+    set:
+      monitoring: true
+    asserts:
+      - exists:
+          path: metadata.labels
   - it: should have correct endpoints
     set:
       monitoring: true

--- a/charts/frankenphp/tests/pdb_test.yaml
+++ b/charts/frankenphp/tests/pdb_test.yaml
@@ -1,0 +1,74 @@
+suite: PodDisruptionBudget
+templates:
+  - pdb.yaml
+tests:
+  - it: should not create PDB when disabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create PDB when enabled
+    set:
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 1
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - isAPIVersion:
+          of: policy/v1
+      - matchRegex:
+          path: metadata.name
+          pattern: RELEASE-NAME$
+
+  - it: should set minAvailable when configured
+    set:
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 2
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: 2
+
+  - it: should default minAvailable to 1
+    set:
+      podDisruptionBudget:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: 1
+
+  - it: should set maxUnavailable when configured
+    set:
+      podDisruptionBudget:
+        enabled: true
+        maxUnavailable: 1
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+      - notExists:
+          path: spec.minAvailable
+
+  - it: should prefer maxUnavailable over minAvailable when both set
+    set:
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 2
+        maxUnavailable: 1
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+      - notExists:
+          path: spec.minAvailable
+
+  - it: should have correct selector labels
+    set:
+      podDisruptionBudget:
+        enabled: true
+    asserts:
+      - exists:
+          path: spec.selector.matchLabels

--- a/charts/frankenphp/tests/probes_test.yaml
+++ b/charts/frankenphp/tests/probes_test.yaml
@@ -88,3 +88,57 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.httpGet.path
           value: /
+---
+suite: Startup Probe
+templates:
+  - deployment.yaml
+tests:
+  - it: should not have startupProbe by default
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].startupProbe
+
+  - it: should set startupProbe when configured
+    set:
+      startupProbe:
+        httpGet:
+          path: /
+          port: http
+        failureThreshold: 30
+        periodSeconds: 10
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.path
+          value: /
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.failureThreshold
+          value: 30
+---
+suite: Startup Probe - Workers
+templates:
+  - worker.yaml
+tests:
+  - it: should not have startupProbe in workers by default
+    set:
+      consumers:
+        - name: "queue"
+          command: "php bin/console messenger:consume"
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].startupProbe
+
+  - it: should set startupProbe in workers when configured
+    set:
+      consumers:
+        - name: "queue"
+          command: "php bin/console messenger:consume"
+      startupProbe:
+        httpGet:
+          path: /
+          port: http
+        failureThreshold: 30
+        periodSeconds: 10
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.failureThreshold
+          value: 30

--- a/charts/frankenphp/tests/probes_test.yaml
+++ b/charts/frankenphp/tests/probes_test.yaml
@@ -1,0 +1,90 @@
+suite: Health Probes
+templates:
+  - deployment.yaml
+tests:
+  - it: should not have livenessProbe by default
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].livenessProbe
+
+  - it: should not have readinessProbe by default
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].readinessProbe
+
+  - it: should set livenessProbe when configured
+    set:
+      livenessProbe:
+        httpGet:
+          path: /
+          port: http
+        initialDelaySeconds: 10
+        periodSeconds: 10
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: http
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.initialDelaySeconds
+          value: 10
+
+  - it: should set readinessProbe when configured
+    set:
+      readinessProbe:
+        httpGet:
+          path: /
+          port: http
+        initialDelaySeconds: 5
+        periodSeconds: 10
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.initialDelaySeconds
+          value: 5
+
+  - it: should support exec probe
+    set:
+      livenessProbe:
+        exec:
+          command:
+            - php
+            - -r
+            - "echo 'ok';"
+        periodSeconds: 30
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.exec.command[0]
+          value: php
+---
+suite: Health Probes - Workers
+templates:
+  - worker.yaml
+tests:
+  - it: should not have livenessProbe in workers by default
+    set:
+      consumers:
+        - name: "queue"
+          command: "php bin/console messenger:consume"
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].livenessProbe
+
+  - it: should set livenessProbe in workers when configured
+    set:
+      consumers:
+        - name: "queue"
+          command: "php bin/console messenger:consume"
+      livenessProbe:
+        httpGet:
+          path: /
+          port: http
+        periodSeconds: 10
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /

--- a/charts/frankenphp/tests/scheduling_test.yaml
+++ b/charts/frankenphp/tests/scheduling_test.yaml
@@ -157,3 +157,241 @@ tests:
       - equal:
           path: spec.template.spec.terminationGracePeriodSeconds
           value: 120
+
+  - it: should set terminationGracePeriodSeconds in CronJob
+    template: crons.yaml
+    set:
+      crons:
+        - name: test-cron
+          schedule: "* * * * *"
+          command: "ls"
+      terminationGracePeriodSeconds: 60
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.terminationGracePeriodSeconds
+          value: 60
+
+  - it: should not set terminationGracePeriodSeconds in CronJob by default
+    template: crons.yaml
+    set:
+      crons:
+        - name: test-cron
+          schedule: "* * * * *"
+          command: "ls"
+    asserts:
+      - notExists:
+          path: spec.jobTemplate.spec.template.spec.terminationGracePeriodSeconds
+
+  - it: should set terminationGracePeriodSeconds in Job
+    template: jobs.yaml
+    set:
+      jobs:
+        - name: test-job
+          command: "ls"
+      terminationGracePeriodSeconds: 60
+    asserts:
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 60
+
+  - it: should not set terminationGracePeriodSeconds in Job by default
+    template: jobs.yaml
+    set:
+      jobs:
+        - name: test-job
+          command: "ls"
+    asserts:
+      - notExists:
+          path: spec.template.spec.terminationGracePeriodSeconds
+
+  - it: should set topologySpreadConstraints in Deployment
+    template: deployment.yaml
+    set:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: frankenphp
+    asserts:
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].topologyKey
+          value: kubernetes.io/hostname
+
+  - it: should not set topologySpreadConstraints by default
+    template: deployment.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.topologySpreadConstraints
+
+  - it: should set priorityClassName in Deployment
+    template: deployment.yaml
+    set:
+      priorityClassName: high-priority
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: high-priority
+
+  - it: should not set priorityClassName by default
+    template: deployment.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.priorityClassName
+
+  - it: should set initContainers in Deployment
+    template: deployment.yaml
+    set:
+      initContainers:
+        - name: wait-for-db
+          image: busybox
+          command: ['sh', '-c', 'until nc -z db 5432; do sleep 2; done']
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: wait-for-db
+
+  - it: should not set initContainers by default
+    template: deployment.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.initContainers
+
+  - it: should set topologySpreadConstraints in Worker
+    template: worker.yaml
+    set:
+      consumers:
+        - name: test-worker
+          command: "ls"
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              app: test
+    asserts:
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].topologyKey
+          value: topology.kubernetes.io/zone
+
+  - it: should set priorityClassName in Worker
+    template: worker.yaml
+    set:
+      consumers:
+        - name: test-worker
+          command: "ls"
+      priorityClassName: low-priority
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: low-priority
+
+  - it: should set initContainers in Worker
+    template: worker.yaml
+    set:
+      consumers:
+        - name: test-worker
+          command: "ls"
+      initContainers:
+        - name: init-setup
+          image: busybox
+          command: ['sh', '-c', 'echo init']
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: init-setup
+
+  - it: should set topologySpreadConstraints in CronJob
+    template: crons.yaml
+    set:
+      crons:
+        - name: test-cron
+          schedule: "* * * * *"
+          command: "ls"
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              app: test
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.topologySpreadConstraints[0].topologyKey
+          value: kubernetes.io/hostname
+
+  - it: should set priorityClassName in CronJob
+    template: crons.yaml
+    set:
+      crons:
+        - name: test-cron
+          schedule: "* * * * *"
+          command: "ls"
+      priorityClassName: high-priority
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.priorityClassName
+          value: high-priority
+
+  - it: should set initContainers in CronJob
+    template: crons.yaml
+    set:
+      crons:
+        - name: test-cron
+          schedule: "* * * * *"
+          command: "ls"
+      initContainers:
+        - name: init-cron
+          image: busybox
+          command: ['sh', '-c', 'echo init']
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.initContainers[0].name
+          value: init-cron
+
+  - it: should set topologySpreadConstraints in Job
+    template: jobs.yaml
+    set:
+      jobs:
+        - name: test-job
+          command: "ls"
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              app: test
+    asserts:
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].topologyKey
+          value: kubernetes.io/hostname
+
+  - it: should set priorityClassName in Job
+    template: jobs.yaml
+    set:
+      jobs:
+        - name: test-job
+          command: "ls"
+      priorityClassName: batch-priority
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: batch-priority
+
+  - it: should set initContainers in Job
+    template: jobs.yaml
+    set:
+      jobs:
+        - name: test-job
+          command: "ls"
+      initContainers:
+        - name: init-job
+          image: busybox
+          command: ['sh', '-c', 'echo init']
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: init-job

--- a/charts/frankenphp/tests/scheduling_test.yaml
+++ b/charts/frankenphp/tests/scheduling_test.yaml
@@ -130,3 +130,30 @@ tests:
       - equal:
           path: spec.template.spec.tolerations[0].key
           value: example_key
+
+  - it: should set terminationGracePeriodSeconds in Deployment
+    template: deployment.yaml
+    set:
+      terminationGracePeriodSeconds: 60
+    asserts:
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 60
+
+  - it: should not set terminationGracePeriodSeconds by default
+    template: deployment.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.terminationGracePeriodSeconds
+
+  - it: should set terminationGracePeriodSeconds in Worker
+    template: worker.yaml
+    set:
+      consumers:
+        - name: "queue"
+          command: "php bin/console messenger:consume"
+      terminationGracePeriodSeconds: 120
+    asserts:
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 120

--- a/charts/frankenphp/tests/security_context_test.yaml
+++ b/charts/frankenphp/tests/security_context_test.yaml
@@ -1,0 +1,87 @@
+suite: Security Context
+templates:
+  - deployment.yaml
+tests:
+  - it: should not have podSecurityContext by default
+    asserts:
+      - notExists:
+          path: spec.template.spec.securityContext
+
+  - it: should set podSecurityContext when configured
+    set:
+      podSecurityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 1000
+
+  - it: should not have containerSecurityContext by default
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].securityContext
+
+  - it: should set containerSecurityContext when configured
+    set:
+      containerSecurityContext:
+        allowPrivilegeEscalation: false
+        runAsNonRoot: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true
+
+  - it: should support capabilities drop in containerSecurityContext
+    set:
+      containerSecurityContext:
+        capabilities:
+          drop:
+            - ALL
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop[0]
+          value: ALL
+---
+suite: Security Context - Workers
+templates:
+  - worker.yaml
+tests:
+  - it: should not have podSecurityContext in workers by default
+    set:
+      consumers:
+        - name: "queue"
+          command: "php bin/console messenger:consume"
+    asserts:
+      - notExists:
+          path: spec.template.spec.securityContext
+
+  - it: should set podSecurityContext in workers when configured
+    set:
+      consumers:
+        - name: "queue"
+          command: "php bin/console messenger:consume"
+      podSecurityContext:
+        runAsNonRoot: true
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+
+  - it: should set containerSecurityContext in workers when configured
+    set:
+      consumers:
+        - name: "queue"
+          command: "php bin/console messenger:consume"
+      containerSecurityContext:
+        allowPrivilegeEscalation: false
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false

--- a/charts/frankenphp/tests/service_test.yaml
+++ b/charts/frankenphp/tests/service_test.yaml
@@ -13,6 +13,22 @@ tests:
       - equal:
           path: spec.type
           value: ClusterIP
+  - it: should use configured service type
+    set:
+      service:
+        type: LoadBalancer
+    asserts:
+      - equal:
+          path: spec.type
+          value: LoadBalancer
+  - it: should use NodePort when configured
+    set:
+      service:
+        type: NodePort
+    asserts:
+      - equal:
+          path: spec.type
+          value: NodePort
   - it: should use configured port
     set:
       service:

--- a/charts/frankenphp/tests/worker_hpa_test.yaml
+++ b/charts/frankenphp/tests/worker_hpa_test.yaml
@@ -1,0 +1,69 @@
+suite: HPA - Workers
+templates:
+  - worker-hpa.yaml
+tests:
+  - it: should not create HPA for workers without autoscale flag
+    set:
+      consumers:
+        - name: "queue"
+          command: "php bin/console messenger:consume"
+          replicas: 2
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create HPA when worker has autoscale enabled
+    set:
+      consumers:
+        - name: "queue"
+          command: "php bin/console messenger:consume"
+          autoscale: true
+          minReplicas: 1
+          maxReplicas: 5
+          targetCPUUtilizationPercentage: 80
+    asserts:
+      - isKind:
+          of: HorizontalPodAutoscaler
+      - isAPIVersion:
+          of: autoscaling/v2
+      - matchRegex:
+          path: metadata.name
+          pattern: -worker-queue$
+      - equal:
+          path: spec.minReplicas
+          value: 1
+      - equal:
+          path: spec.maxReplicas
+          value: 5
+
+  - it: should set CPU metric for worker HPA
+    set:
+      consumers:
+        - name: "queue"
+          command: "php bin/console messenger:consume"
+          autoscale: true
+          targetCPUUtilizationPercentage: 75
+    asserts:
+      - equal:
+          path: spec.metrics[0].resource.name
+          value: cpu
+      - equal:
+          path: spec.metrics[0].resource.target.averageUtilization
+          value: 75
+
+  - it: should create HPA only for workers with autoscale flag when mixed
+    set:
+      consumers:
+        - name: "queue"
+          command: "cmd"
+          autoscale: true
+          maxReplicas: 5
+        - name: "emails"
+          command: "cmd"
+          replicas: 2
+    asserts:
+      - hasDocuments:
+          count: 1
+      - matchRegex:
+          path: metadata.name
+          pattern: -worker-queue$

--- a/charts/frankenphp/values.schema.json
+++ b/charts/frankenphp/values.schema.json
@@ -352,6 +352,22 @@
             "items": {
                 "type": "object"
             }
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "description": "Pod-level security context applied to all workloads"
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "description": "Container-level security context applied to all containers"
+        },
+        "livenessProbe": {
+            "type": "object",
+            "description": "Liveness probe configuration for the main deployment and workers"
+        },
+        "readinessProbe": {
+            "type": "object",
+            "description": "Readiness probe configuration for the main deployment and workers"
         }
     }
 }

--- a/charts/frankenphp/values.schema.json
+++ b/charts/frankenphp/values.schema.json
@@ -426,6 +426,22 @@
         "readinessProbe": {
             "type": "object",
             "description": "Readiness probe configuration for the main deployment and workers"
+        },
+        "podDisruptionBudget": {
+            "type": "object",
+            "description": "PodDisruptionBudget configuration",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable PodDisruptionBudget"
+                },
+                "minAvailable": {
+                    "description": "Minimum number of pods that must be available (integer or percentage string)"
+                },
+                "maxUnavailable": {
+                    "description": "Maximum number of pods that can be unavailable (integer or percentage string)"
+                }
+            }
         }
     }
 }

--- a/charts/frankenphp/values.schema.json
+++ b/charts/frankenphp/values.schema.json
@@ -101,12 +101,17 @@
             "description": "Environment variables",
             "items": {
                 "type": "object",
+                "required": ["name"],
                 "properties": {
                     "name": {
                         "type": "string"
                     },
                     "value": {
                         "type": "string"
+                    },
+                    "valueFrom": {
+                        "type": "object",
+                        "description": "Source for the environment variable's value (secretKeyRef, configMapKeyRef, fieldRef, resourceFieldRef)"
                     }
                 }
             }
@@ -310,6 +315,26 @@
                             "Replace"
                         ],
                         "description": "Concurrency policy"
+                    },
+                    "restartPolicy": {
+                        "type": "string",
+                        "enum": ["Never", "OnFailure"],
+                        "description": "Pod restart policy for cron job pods"
+                    },
+                    "successfulJobsHistoryLimit": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "description": "Number of successful finished jobs to retain"
+                    },
+                    "failedJobsHistoryLimit": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "description": "Number of failed finished jobs to retain"
+                    },
+                    "backoffLimit": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "description": "Number of retries before marking the job as failed"
                     }
                 }
             }
@@ -346,6 +371,31 @@
                             "Never"
                         ],
                         "description": "Restart policy"
+                    },
+                    "ttlSecondsAfterFinished": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "description": "Seconds after which a finished job is automatically deleted"
+                    },
+                    "resources": {
+                        "type": "object",
+                        "description": "Per-job resource overrides (takes precedence over global resources)",
+                        "properties": {
+                            "requests": {
+                                "type": "object",
+                                "properties": {
+                                    "cpu": {"type": "string"},
+                                    "memory": {"type": "string"}
+                                }
+                            },
+                            "limits": {
+                                "type": "object",
+                                "properties": {
+                                    "cpu": {"type": "string"},
+                                    "memory": {"type": "string"}
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -466,6 +516,24 @@
             "type": "integer",
             "minimum": 0,
             "description": "Override the default termination grace period for all pods"
+        },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology spread constraints to control how pods are spread across failure domains",
+            "items": {
+                "type": "object"
+            }
+        },
+        "priorityClassName": {
+            "type": "string",
+            "description": "PriorityClass name to assign to all pods for scheduling priority"
+        },
+        "initContainers": {
+            "type": "array",
+            "description": "Init containers to run before the main app container starts",
+            "items": {
+                "type": "object"
+            }
         }
     }
 }

--- a/charts/frankenphp/values.schema.json
+++ b/charts/frankenphp/values.schema.json
@@ -249,6 +249,32 @@
                         "type": "integer",
                         "minimum": 0,
                         "description": "Number of replicas"
+                    },
+                    "autoscale": {
+                        "type": "boolean",
+                        "description": "Enable HPA for this worker (omits replicas from Deployment)"
+                    },
+                    "minReplicas": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "description": "HPA minimum replicas for this worker"
+                    },
+                    "maxReplicas": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "description": "HPA maximum replicas for this worker"
+                    },
+                    "targetCPUUtilizationPercentage": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 100,
+                        "description": "HPA target CPU utilization percentage for this worker"
+                    },
+                    "targetMemoryUtilizationPercentage": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 100,
+                        "description": "HPA target memory utilization percentage for this worker"
                     }
                 }
             }
@@ -351,6 +377,38 @@
             "description": "Extra volume mounts to add to all containers",
             "items": {
                 "type": "object"
+            }
+        },
+        "autoscaling": {
+            "type": "object",
+            "description": "HorizontalPodAutoscaler configuration for the main deployment",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable HPA for the main deployment"
+                },
+                "minReplicas": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Minimum number of replicas"
+                },
+                "maxReplicas": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Maximum number of replicas"
+                },
+                "targetCPUUtilizationPercentage": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 100,
+                    "description": "Target CPU utilization percentage"
+                },
+                "targetMemoryUtilizationPercentage": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 100,
+                    "description": "Target memory utilization percentage"
+                }
             }
         },
         "podSecurityContext": {

--- a/charts/frankenphp/values.schema.json
+++ b/charts/frankenphp/values.schema.json
@@ -427,6 +427,10 @@
             "type": "object",
             "description": "Readiness probe configuration for the main deployment and workers"
         },
+        "startupProbe": {
+            "type": "object",
+            "description": "Startup probe configuration for the main deployment and workers. Useful for slow-starting apps."
+        },
         "podDisruptionBudget": {
             "type": "object",
             "description": "PodDisruptionBudget configuration",

--- a/charts/frankenphp/values.schema.json
+++ b/charts/frankenphp/values.schema.json
@@ -442,6 +442,26 @@
                     "description": "Maximum number of pods that can be unavailable (integer or percentage string)"
                 }
             }
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "Override the chart name used in resource names and labels"
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "Override the fully qualified app name used in resource names"
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all pods",
+            "additionalProperties": {
+                "type": "string"
+            }
+        },
+        "terminationGracePeriodSeconds": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Override the default termination grace period for all pods"
         }
     }
 }

--- a/charts/frankenphp/values.yaml
+++ b/charts/frankenphp/values.yaml
@@ -5,7 +5,14 @@ image:
 #  pullSecrets:
 #     - name: myRegistryKeySecret
 
+# nameOverride and fullnameOverride let you change the chart name used in resource names and labels.
+#nameOverride: ""
+#fullnameOverride: ""
 
+# Annotations to add to all pods (deployment, workers, crons, jobs).
+podAnnotations: {}
+#  prometheus.io/scrape: "true"
+#  custom-annotation: "value"
 
 php:
   ini: ""
@@ -96,6 +103,10 @@ affinity: {}
 nodeSelector: {}
 
 tolerations: []
+
+# terminationGracePeriodSeconds defines how long Kubernetes waits for a pod to shut down gracefully.
+# Increase this for workers that need time to finish processing current messages.
+#terminationGracePeriodSeconds: 30
 
 # Extra volumes to mount into all pods (deployment, workers, crons, jobs).
 # Use this to inject secrets or configmaps as files into your containers.

--- a/charts/frankenphp/values.yaml
+++ b/charts/frankenphp/values.yaml
@@ -98,6 +98,15 @@ readinessProbe: {}
 #  periodSeconds: 10
 #  failureThreshold: 3
 
+# startupProbe is useful for applications with long startup times (e.g. Symfony, Laravel).
+# It delays liveness/readiness checks until the app has had time to boot.
+startupProbe: {}
+#  httpGet:
+#    path: /
+#    port: http
+#  failureThreshold: 30
+#  periodSeconds: 10
+
 affinity: {}
 
 nodeSelector: {}

--- a/charts/frankenphp/values.yaml
+++ b/charts/frankenphp/values.yaml
@@ -113,6 +113,26 @@ nodeSelector: {}
 
 tolerations: []
 
+# topologySpreadConstraints controls how pods are spread across failure domains (nodes, zones).
+# Useful for ensuring high availability across availability zones.
+topologySpreadConstraints: []
+#  - maxSkew: 1
+#    topologyKey: kubernetes.io/hostname
+#    whenUnsatisfiable: DoNotSchedule
+#    labelSelector:
+#      matchLabels:
+#        app.kubernetes.io/name: frankenphp
+
+# priorityClassName assigns a PriorityClass to all pods, affecting scheduling order under resource pressure.
+#priorityClassName: ""
+
+# initContainers defines a list of init containers to run before the main app container starts.
+# Useful for database migration checks, config rendering, or dependency readiness gates.
+initContainers: []
+#  - name: wait-for-db
+#    image: busybox
+#    command: ['sh', '-c', 'until nc -z db 5432; do sleep 2; done']
+
 # terminationGracePeriodSeconds defines how long Kubernetes waits for a pod to shut down gracefully.
 # Increase this for workers that need time to finish processing current messages.
 #terminationGracePeriodSeconds: 30

--- a/charts/frankenphp/values.yaml
+++ b/charts/frankenphp/values.yaml
@@ -31,6 +31,13 @@ caddyfile: ""
 deployment:
   replicas: 3
 
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 80
+#  targetMemoryUtilizationPercentage: 80
+
 crons: []
 #  - name: "my-super-cron"
 #    command: "php public/command.php"

--- a/charts/frankenphp/values.yaml
+++ b/charts/frankenphp/values.yaml
@@ -50,6 +50,40 @@ consumers: []
 #    command: "php bin/console messenger:consume"
 #    replicas: 1
 
+podSecurityContext: {}
+#  runAsNonRoot: true
+#  runAsUser: 1000
+#  fsGroup: 1000
+#  seccompProfile:
+#    type: RuntimeDefault
+
+containerSecurityContext: {}
+#  allowPrivilegeEscalation: false
+#  readOnlyRootFilesystem: false
+#  runAsNonRoot: true
+#  runAsUser: 1000
+#  capabilities:
+#    drop:
+#      - ALL
+#  seccompProfile:
+#    type: RuntimeDefault
+
+livenessProbe: {}
+#  httpGet:
+#    path: /
+#    port: http
+#  initialDelaySeconds: 10
+#  periodSeconds: 10
+#  failureThreshold: 3
+
+readinessProbe: {}
+#  httpGet:
+#    path: /
+#    port: http
+#  initialDelaySeconds: 5
+#  periodSeconds: 10
+#  failureThreshold: 3
+
 affinity: {}
 
 nodeSelector: {}

--- a/charts/frankenphp/values.yaml
+++ b/charts/frankenphp/values.yaml
@@ -149,6 +149,11 @@ ingress: {}
 
 monitoring: false
 
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+#  maxUnavailable: 1
+
 #serviceAccount:
 #  create: false
 #  name: ""

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -98,3 +98,21 @@ readinessProbe:
 ```
 
 You can also use `exec` or `tcpSocket` probe types. Probes are applied to the main deployment and all workers.
+
+## Startup Probe
+
+For applications with long startup times (e.g. Symfony cache warmup, Laravel bootstrap), use a startup
+probe to prevent premature liveness/readiness failures during the boot phase:
+
+```yaml
+# Allow up to 5 minutes for the app to start (30 × 10s)
+startupProbe:
+  httpGet:
+    path: /
+    port: http
+  failureThreshold: 30
+  periodSeconds: 10
+```
+
+While the startup probe is active, liveness and readiness probes are paused. Only after the startup
+probe succeeds do the other probes take over.

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -54,3 +54,47 @@ env:
   - name: MY_CUSTOM_VARIABLE
     value: "some-value"
 ```
+
+## Security Context
+
+Harden your containers with pod- and container-level security contexts:
+
+```yaml
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  fsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
+
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  runAsNonRoot: true
+  capabilities:
+    drop:
+      - ALL
+```
+
+Both contexts are optional and empty by default to preserve backwards compatibility with all FrankenPHP images.
+
+## Health Probes
+
+Add liveness and readiness probes to improve reliability and traffic management:
+
+```yaml
+livenessProbe:
+  httpGet:
+    path: /
+    port: http
+  initialDelaySeconds: 10
+  periodSeconds: 10
+
+readinessProbe:
+  httpGet:
+    path: /
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+```
+
+You can also use `exec` or `tcpSocket` probe types. Probes are applied to the main deployment and all workers.

--- a/docs/features.md
+++ b/docs/features.md
@@ -187,3 +187,18 @@ readinessProbe:
 ```
 
 Probes are applied to both the main deployment and workers. By default, no probes are configured.
+
+### Startup Probe
+
+For slow-starting applications, add a startup probe to delay liveness/readiness checks until boot completes:
+
+```yaml
+startupProbe:
+  httpGet:
+    path: /
+    port: http
+  failureThreshold: 30   # 30 × 10s = 5 minutes max startup time
+  periodSeconds: 10
+```
+
+See `examples/13-startup-probe.yaml` for a full example.

--- a/docs/features.md
+++ b/docs/features.md
@@ -87,3 +87,103 @@ By using annotations like `"helm.sh/hook": post-install`, you ensure that migrat
 - **Environment Variables**: The `env` list defined at the root of `values.yaml` is injected into **all** pods (Main application, Workers, Crons, and Jobs).
 - **PHP Config**: The `php.ini` defined globally is also shared across all these components.
 - **Service Account**: All components share the same ServiceAccount configuration.
+
+## Autoscaling (HPA)
+
+The chart supports Kubernetes `HorizontalPodAutoscaler` (autoscaling/v2) for the main deployment and individual workers.
+
+### Main Deployment HPA
+
+```yaml
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 80
+  targetMemoryUtilizationPercentage: 75
+```
+
+> **Note:** When `autoscaling.enabled: true`, the `spec.replicas` field is omitted from the Deployment to avoid conflicts with the HPA. You must have [metrics-server](https://github.com/kubernetes-sigs/metrics-server) installed in your cluster.
+
+### Worker HPA
+
+Each worker can independently enable HPA via the `autoscale` flag:
+
+```yaml
+consumers:
+  - name: "queue"
+    command: "php bin/console messenger:consume async"
+    autoscale: true
+    minReplicas: 1
+    maxReplicas: 5
+    targetCPUUtilizationPercentage: 80
+```
+
+## Pod Disruption Budget
+
+To ensure availability during voluntary disruptions (e.g., node maintenance), enable the PodDisruptionBudget:
+
+```yaml
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 2  # must be less than deployment.replicas
+```
+
+Or use `maxUnavailable` instead of `minAvailable`:
+
+```yaml
+podDisruptionBudget:
+  enabled: true
+  maxUnavailable: 1
+```
+
+> **Note:** A PDB only makes sense when you have more than 1 replica. Ensure `minAvailable` is less than your replica count, otherwise node drains will block.
+
+## Security Context
+
+You can configure pod- and container-level security contexts to harden your workloads:
+
+```yaml
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  fsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
+
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  runAsNonRoot: true
+  runAsUser: 1000
+  capabilities:
+    drop:
+      - ALL
+```
+
+Security contexts are applied to all workloads: the main deployment, workers, crons, and jobs.
+
+> **Note:** `readOnlyRootFilesystem: true` may cause issues with FrankenPHP/Caddy as it writes temporary files. Test carefully before enabling this in production.
+
+## Health Probes
+
+Configure liveness and readiness probes to enable Kubernetes self-healing and proper traffic management:
+
+```yaml
+livenessProbe:
+  httpGet:
+    path: /
+    port: http
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  failureThreshold: 3
+```
+
+Probes are applied to both the main deployment and workers. By default, no probes are configured.

--- a/docs/guides/production.md
+++ b/docs/guides/production.md
@@ -28,6 +28,71 @@ resources:
 
 - Use a specific image tag (e.g., `1.1.0-php8.3`) instead of `latest` to ensure reproducibility.
 - If your registry requires authentication, configure `imagePullSecrets`.
+- Harden your containers with security contexts:
+
+```yaml
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  fsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
+
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  runAsNonRoot: true
+  capabilities:
+    drop:
+      - ALL
+```
+
+> **Note:** `readOnlyRootFilesystem: true` may cause issues with FrankenPHP/Caddy. Test carefully.
+
+## Pod Disruption Budget
+
+For production, configure a PodDisruptionBudget to maintain availability during node maintenance:
+
+```yaml
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 2  # must be less than deployment.replicas
+```
+
+## Autoscaling
+
+Use HPA to automatically scale the deployment based on CPU/memory:
+
+```yaml
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 80
+```
+
+> **Requirement:** [metrics-server](https://github.com/kubernetes-sigs/metrics-server) must be installed. Also set `resources.requests.cpu` — HPA calculates utilization relative to requests.
+
+## Health Probes
+
+Add probes to enable Kubernetes self-healing and proper traffic steering:
+
+```yaml
+livenessProbe:
+  httpGet:
+    path: /
+    port: http
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  failureThreshold: 3
+```
 
 ## Networking
 

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -1,0 +1,162 @@
+# Troubleshooting Guide
+
+This guide covers common issues when deploying FrankenPHP with this Helm chart.
+
+## Pod Fails to Start (`CrashLoopBackOff`)
+
+**Symptoms:** Pod repeatedly restarts, status shows `CrashLoopBackOff`.
+
+**Steps to diagnose:**
+```bash
+# Check pod status and events
+kubectl describe pod <pod-name>
+
+# View container logs
+kubectl logs <pod-name> --previous
+```
+
+**Common causes:**
+- **Wrong image tag** — ensure `image.repository` and `image.tag` are correct and the image is accessible.
+- **Missing environment variable** — your application may require specific env vars (e.g., `DATABASE_URL`). Add them to `env:` or inject via a Secret.
+- **Security context too restrictive** — if you set `containerSecurityContext.runAsNonRoot: true` but your image runs as root by default, the container will fail. Either change the image or set `runAsUser` to the appropriate UID.
+- **Port conflict** — if `SERVER_NAME` is set to bind on a privileged port (< 1024) and the container runs as non-root, the bind will fail. Use `:8080` or configure a higher port.
+
+---
+
+## OOMKilled (Out of Memory)
+
+**Symptoms:** Pod is terminated with `OOMKilled`.
+
+**Fix:** Increase memory limits and/or adjust PHP's `memory_limit`:
+
+```yaml
+resources:
+  limits:
+    memory: "512Mi"
+
+php:
+  ini: |
+    memory_limit = 256M
+```
+
+---
+
+## Worker Not Starting
+
+**Symptoms:** Worker Deployment exists but pods are not running.
+
+**Check:**
+```bash
+kubectl describe deployment <release-name>-worker-<name>
+kubectl logs <worker-pod-name>
+```
+
+**Common causes:**
+- `command` is invalid — the command is executed via `/bin/sh -c`. Verify it works in your container locally.
+- The worker's preStop hook creates `/tmp/kill_me`. If your application checks this file to exit, ensure your command handles it properly.
+
+---
+
+## Custom PHP ini Not Applied
+
+**Symptoms:** PHP settings (e.g., `memory_limit`) appear unchanged.
+
+**Verify the ConfigMap was created:**
+```bash
+kubectl get configmap <release-name>-php-ini -o yaml
+```
+
+**Check the volume mount:**
+```bash
+kubectl exec <pod-name> -- cat /usr/local/etc/php/conf.d/99-custom.ini
+```
+
+The file should contain your settings. If it doesn't, ensure `php.ini` is set in `values.yaml`.
+
+---
+
+## Ingress / TLS Not Working
+
+**Symptoms:** Application is unreachable via Ingress, or HTTPS certificate is not issued.
+
+**Check the Ingress resource:**
+```bash
+kubectl describe ingress <release-name>
+```
+
+**Common causes:**
+- `ingress.enabled` is `false` (or not set) — set `ingress.enabled: true`.
+- Wrong `ingress.className` — set it to your installed Ingress controller (e.g., `nginx`, `traefik`).
+- cert-manager not installed — TLS via cert-manager requires cert-manager to be running. Check with `kubectl get pods -n cert-manager`.
+- Missing annotation — for cert-manager, ensure you have:
+  ```yaml
+  ingress:
+    annotations:
+      cert-manager.io/cluster-issuer: letsencrypt-prod
+  ```
+
+---
+
+## HPA Not Scaling
+
+**Symptoms:** Pod count stays fixed despite high CPU/memory usage.
+
+**Check:**
+```bash
+kubectl get hpa <release-name>
+kubectl describe hpa <release-name>
+```
+
+**Common causes:**
+- **metrics-server not installed** — HPA requires the Kubernetes metrics-server. Install it or check:
+  ```bash
+  kubectl top pods
+  ```
+- **No resource requests set** — HPA calculates utilization based on resource requests. Ensure you have `resources.requests.cpu` defined.
+- `autoscaling.enabled` is `false` — verify your values override has `autoscaling.enabled: true`.
+
+---
+
+## PodDisruptionBudget Blocking Node Drain
+
+**Symptoms:** `kubectl drain` hangs or times out.
+
+**Cause:** If `podDisruptionBudget.minAvailable` equals the total number of replicas, Kubernetes cannot evict any pod.
+
+**Fix:** Ensure `minAvailable` is less than `deployment.replicas`:
+```yaml
+deployment:
+  replicas: 3
+
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 2   # at least 1 pod can be evicted
+```
+
+---
+
+## Image Pull Errors (`ImagePullBackOff`)
+
+**Symptoms:** Pod stuck in `ImagePullBackOff`.
+
+**Diagnose:**
+```bash
+kubectl describe pod <pod-name>
+```
+
+**Fix:** If using a private registry, configure `image.pullSecrets`:
+```yaml
+image:
+  repository: my-private-registry.example.com/my-app
+  tag: "1.0.0"
+  pullSecrets:
+    - name: my-registry-secret
+```
+
+Create the secret with:
+```bash
+kubectl create secret docker-registry my-registry-secret \
+  --docker-server=my-private-registry.example.com \
+  --docker-username=<username> \
+  --docker-password=<password>
+```

--- a/examples/12-security.yaml
+++ b/examples/12-security.yaml
@@ -1,0 +1,48 @@
+# Example: Security-hardened deployment
+# Demonstrates podSecurityContext, containerSecurityContext, and health probes.
+# Note: FrankenPHP/Caddy may write to /tmp and /var — avoid readOnlyRootFilesystem: true
+# unless your image is specifically built to handle it.
+image:
+  repository: dunglas/frankenphp
+  tag: latest
+
+deployment:
+  replicas: 2
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  fsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
+
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  runAsNonRoot: true
+  runAsUser: 1000
+  capabilities:
+    drop:
+      - ALL
+
+livenessProbe:
+  httpGet:
+    path: /
+    port: http
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  failureThreshold: 3
+
+resources:
+  requests:
+    cpu: "100m"
+    memory: "128Mi"
+  limits:
+    memory: "256Mi"

--- a/examples/13-startup-probe.yaml
+++ b/examples/13-startup-probe.yaml
@@ -1,0 +1,41 @@
+# Example: Startup probe for slow-starting applications
+# Use startupProbe when your app has a long boot time (e.g. Symfony warmup, Laravel boot).
+# While the startupProbe is active, liveness and readiness checks are paused,
+# preventing premature restarts during startup.
+image:
+  repository: dunglas/frankenphp
+  tag: latest
+
+deployment:
+  replicas: 2
+
+# Give the app up to 5 minutes to start (30 failures × 10s period)
+startupProbe:
+  httpGet:
+    path: /
+    port: http
+  failureThreshold: 30
+  periodSeconds: 10
+
+# Once started, check health every 10s
+livenessProbe:
+  httpGet:
+    path: /
+    port: http
+  periodSeconds: 10
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  failureThreshold: 3
+
+resources:
+  requests:
+    cpu: "100m"
+    memory: "128Mi"
+  limits:
+    memory: "256Mi"


### PR DESCRIPTION
## Summary
- Add `topologySpreadConstraints` for pod spread across failure domains
- Add `priorityClassName` for pod scheduling priority
- Add `initContainers` support for pre-start setup containers
- Fix template consistency across Deployment, worker, CronJob, and Job templates

## Test results
- `make lint`: PASS
- `make unit-test`: 21 suites, 135 tests — all PASS
- `make validate`: all 14 example files valid (kubeconform k8s 1.29)

## Notes
Stacked on: `feat/startup-probe`

🤖 Generated with [Claude Code](https://claude.com/claude-code)